### PR TITLE
Database redesigned and backend re-implemented to allow for greater data storage per user.

### DIFF
--- a/packages/express-backend/backend.js
+++ b/packages/express-backend/backend.js
@@ -6,16 +6,12 @@ import querystring from "querystring";
 import cookieParser from "cookie-parser";
 import mongoose from "mongoose";
 import UserData from "./models/UserData.js";
-import UserArtists from "./models/UserArtists.js";
-import UserTracks from "./models/UserTracks.js";
-import UserAlbums from "./models/UserAlbums.js";
-import UserGenreCounts from "./models/UserGenreCounts.js";
 import {
   createOrUpdateUserArtists,
   createOrUpdateUserTracks,
   createOrUpdateUserAlbums,
   createOrUpdateUserGenreCounts,
-} from "./mongoUtils.js";
+} from "./utils/mongoUtils.js";
 import {
   getTopNArtists,
   getTopNTracks,
@@ -33,7 +29,7 @@ const client_id = process.env.SPOTIFY_CLIENT_ID;
 const client_secret = process.env.SPOTIFY_CLIENT_SECRET;
 const redirect_uri = process.env.SPOTIFY_REDIRECT_URI;
 const mongoURI = process.env.MONGODB_URI;
-const maxItems = 100; // max items to load from Spotify API calls
+const maxItems = 750; // max items to load from Spotify API calls
 
 const appFeUrl = process.env.DEV_URL;
 

--- a/packages/express-backend/models/UserAlbums.js
+++ b/packages/express-backend/models/UserAlbums.js
@@ -1,0 +1,19 @@
+import mongoose from "mongoose";
+
+const UserAlbumsSchema = new mongoose.Schema({
+  user: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "UserData",
+    required: true,
+  },
+  term: {
+    type: String,
+    enum: ["short_term", "medium_term", "long_term"],
+    required: true,
+  },
+  data: { type: Array, required: true },
+});
+
+const UserAlbums = mongoose.model("UserAlbums", UserAlbumsSchema);
+
+export default UserAlbums;

--- a/packages/express-backend/models/UserArtists.js
+++ b/packages/express-backend/models/UserArtists.js
@@ -1,0 +1,19 @@
+import mongoose from "mongoose";
+
+const UserArtistsSchema = new mongoose.Schema({
+  user: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "UserData",
+    required: true,
+  },
+  term: {
+    type: String,
+    enum: ["short_term", "medium_term", "long_term"],
+    required: true,
+  },
+  data: { type: Array, required: true },
+});
+
+const UserArtists = mongoose.model("UserArtists", UserArtistsSchema);
+
+export default UserArtists;

--- a/packages/express-backend/models/UserData.js
+++ b/packages/express-backend/models/UserData.js
@@ -7,24 +7,30 @@ const UserDataSchema = new mongoose.Schema({
   username: String,
   profilePicture: String,
   allArtists: {
-    short_term: Array,
-    medium_term: Array,
-    long_term: Array,
+    short_term: { type: mongoose.Schema.Types.ObjectId, ref: "UserArtists" },
+    medium_term: { type: mongoose.Schema.Types.ObjectId, ref: "UserArtists" },
+    long_term: { type: mongoose.Schema.Types.ObjectId, ref: "UserArtists" },
   },
   allTracks: {
-    short_term: Array,
-    medium_term: Array,
-    long_term: Array,
+    short_term: { type: mongoose.Schema.Types.ObjectId, ref: "UserTracks" },
+    medium_term: { type: mongoose.Schema.Types.ObjectId, ref: "UserTracks" },
+    long_term: { type: mongoose.Schema.Types.ObjectId, ref: "UserTracks" },
   },
   allAlbums: {
-    short_term: Array,
-    medium_term: Array,
-    long_term: Array,
+    short_term: { type: mongoose.Schema.Types.ObjectId, ref: "UserAlbums" },
+    medium_term: { type: mongoose.Schema.Types.ObjectId, ref: "UserAlbums" },
+    long_term: { type: mongoose.Schema.Types.ObjectId, ref: "UserAlbums" },
   },
   genreCounts: {
-    short_term: Array,
-    medium_term: Array,
-    long_term: Array,
+    short_term: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "UserGenreCounts",
+    },
+    medium_term: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "UserGenreCounts",
+    },
+    long_term: { type: mongoose.Schema.Types.ObjectId, ref: "UserGenreCounts" },
   },
   last_updated: { type: Date, default: Date.now },
 });

--- a/packages/express-backend/models/UserGenreCounts.js
+++ b/packages/express-backend/models/UserGenreCounts.js
@@ -1,0 +1,22 @@
+import mongoose from "mongoose";
+
+const UserGenreCountsSchema = new mongoose.Schema({
+  user: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "UserData",
+    required: true,
+  },
+  term: {
+    type: String,
+    enum: ["short_term", "medium_term", "long_term"],
+    required: true,
+  },
+  data: { type: Array, required: true },
+});
+
+const UserGenreCounts = mongoose.model(
+  "UserGenreCounts",
+  UserGenreCountsSchema
+);
+
+export default UserGenreCounts;

--- a/packages/express-backend/models/UserTracks.js
+++ b/packages/express-backend/models/UserTracks.js
@@ -1,0 +1,19 @@
+import mongoose from "mongoose";
+
+const UserTracksSchema = new mongoose.Schema({
+  user: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "UserData",
+    required: true,
+  },
+  term: {
+    type: String,
+    enum: ["short_term", "medium_term", "long_term"],
+    required: true,
+  },
+  data: { type: Array, required: true },
+});
+
+const UserTracks = mongoose.model("UserTracks", UserTracksSchema);
+
+export default UserTracks;

--- a/packages/express-backend/utils/mongoUtils.js
+++ b/packages/express-backend/utils/mongoUtils.js
@@ -1,0 +1,116 @@
+import UserArtists from "../models/UserArtists.js";
+import UserTracks from "../models/UserTracks.js";
+import UserAlbums from "../models/UserAlbums.js";
+import UserGenreCounts from "../models/UserGenreCounts.js";
+
+export async function createOrUpdateUserArtists(userData, term, data) {
+  console.log("Creating or updates user artists data");
+  let userArtistsId = userData.allArtists[term];
+  if (userArtistsId) {
+    let userArtists = await UserArtists.findById(userArtistsId);
+    if (userArtists) {
+      userArtists.data = data;
+      await userArtists.save();
+    } else {
+      const newUserArtists = new UserArtists({
+        user: userData._id,
+        term: term,
+        data: data,
+      });
+      await newUserArtists.save();
+      userData.allArtists[term] = newUserArtists._id;
+    }
+  } else {
+    const newUserArtists = new UserArtists({
+      user: userData._id,
+      term: term,
+      data: data,
+    });
+    await newUserArtists.save();
+    userData.allArtists[term] = newUserArtists._id;
+  }
+}
+
+export async function createOrUpdateUserTracks(userData, term, data) {
+  console.log("Creating or updates user tracks data");
+  let userTracksId = userData.allTracks[term];
+  if (userTracksId) {
+    let userTracks = await UserTracks.findById(userTracksId);
+    if (userTracks) {
+      userTracks.data = data;
+      await userTracks.save();
+    } else {
+      const newUserTracks = new UserTracks({
+        user: userData._id,
+        term: term,
+        data: data,
+      });
+      await newUserTracks.save();
+      userData.allTracks[term] = newUserTracks._id;
+    }
+  } else {
+    const newUserTracks = new UserTracks({
+      user: userData._id,
+      term: term,
+      data: data,
+    });
+    await newUserTracks.save();
+    userData.allTracks[term] = newUserTracks._id;
+  }
+}
+
+export async function createOrUpdateUserAlbums(userData, term, data) {
+  console.log("Creating or updates user albums data");
+  let userAlbumsId = userData.allAlbums[term];
+  if (userAlbumsId) {
+    let userAlbums = await UserAlbums.findById(userAlbumsId);
+    if (userAlbums) {
+      userAlbums.data = data;
+      await userAlbums.save();
+    } else {
+      const newUserAlbums = new UserAlbums({
+        user: userData._id,
+        term: term,
+        data: data,
+      });
+      await newUserAlbums.save();
+      userData.allAlbums[term] = newUserAlbums._id;
+    }
+  } else {
+    const newUserAlbums = new UserAlbums({
+      user: userData._id,
+      term: term,
+      data: data,
+    });
+    await newUserAlbums.save();
+    userData.allAlbums[term] = newUserAlbums._id;
+  }
+}
+
+export async function createOrUpdateUserGenreCounts(userData, term, data) {
+  console.log("Creating or updates user genres data");
+  let userGenreCountsId = userData.genreCounts[term];
+  if (userGenreCountsId) {
+    let userGenreCounts = await UserGenreCounts.findById(userGenreCountsId);
+    if (userGenreCounts) {
+      userGenreCounts.data = data;
+      await userGenreCounts.save();
+    } else {
+      const newUserGenreCounts = new UserGenreCounts({
+        user: userData._id,
+        term: term,
+        data: data,
+      });
+      await newUserGenreCounts.save();
+      userData.genreCounts[term] = newUserGenreCounts._id;
+    }
+  } else {
+    const newUserGenreCounts = new UserGenreCounts({
+      user: userData._id,
+      term: term,
+      data: data,
+    });
+    await newUserGenreCounts.save();
+    userData.genreCounts[term] = newUserGenreCounts._id;
+  }
+}

--- a/packages/react-frontend/src/pages/home.jsx
+++ b/packages/react-frontend/src/pages/home.jsx
@@ -92,8 +92,8 @@ function Home({
           <div className="scale-75">
             <div className="relative group">
               <ImageGrid
-                imageUrls={albumImageUrls.slice(0, 2500)} // match grid size (50x50 = 2500)
-                gridSize={50} // use max grid size of up to 50x50
+                imageUrls={albumImageUrls.slice(0, 625)} // match grid size (25x25 = 625)
+                gridSize={25} // use max grid size of up to 25x25
               />
             </div>
           </div>


### PR DESCRIPTION
- Database now split into 5 collections rather than 1.
- The main UserData collection holds the users main information like SpotifyID, username, etc, and references documents in the rest of the 4 collections (UserTracks, UserAlbums, UserArtists, UserGenreCounts)
- In those collections, each document holds a time range and a dataset.
- Now, rather than being limited because all of a user's data is in a single document, each user's data is split between 1 + 3 * 4 = 13 documents, allowing us to greatly increase the amount of information we gather and store per user.